### PR TITLE
simulate new repo token sale

### DIFF
--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -381,7 +381,14 @@ contract Strategy is BaseStrategy, Pausable, ReentrancyGuard {
             );
         }
 
-        simulatedLiquidityRatio = (liquidBalance - proceeds) / _totalAssetValue(liquidBalance);
+        uint256 assetValue = _totalAssetValue(liquidBalance);
+
+        if (assetValue == 0) {simulatedLiquidityRatio = 0;}
+        else {
+            simulatedLiquidityRatio = (liquidBalance - proceeds) * 10 ** 18 / assetValue;
+        }
+
+
     }
 
     /**

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -381,7 +381,7 @@ contract Strategy is BaseStrategy, Pausable, ReentrancyGuard {
             );
         }
 
-        simulatedLiquidityRatio = _liquidReserveRatio(liquidBalance - proceeds);
+        simulatedLiquidityRatio = (liquidBalance - proceeds) / _totalAssetValue(liquidBalance);
     }
 
     /**


### PR DESCRIPTION
For a new repo token that hasn't been sold yet, the asset value of this new repo token is omitted from the liquid concentration calculation since it is not in the repo token list yet in the simulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the calculation method for the liquidity ratio, enhancing accuracy in financial assessments.

- **Bug Fixes**
	- Improved the interpretation of the liquidity ratio for better operational insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->