### PR TITLE
Fixes to the list insert functions

### DIFF
--- a/src/RepoTokenList.sol
+++ b/src/RepoTokenList.sol
@@ -384,6 +384,7 @@ library RepoTokenList {
         // If the list is empty, set the new repoToken as the head
         if (current == NULL_NODE) {
             listData.head = repoToken;
+            listData.nodes[repoToken].next = NULL_NODE;
             return;
         }
 
@@ -399,7 +400,7 @@ library RepoTokenList {
             uint256 maturityToInsert = getRepoTokenMaturity(repoToken);
 
             // Insert repoToken before current if its maturity is less than or equal
-            if (maturityToInsert <= currentMaturity) {
+            if (maturityToInsert < currentMaturity) {
                 if (prev == NULL_NODE) {
                     listData.head = repoToken;
                 } else {
@@ -415,6 +416,7 @@ library RepoTokenList {
             // If at the end of the list, insert repoToken after current
             if (next == NULL_NODE) {
                 listData.nodes[current].next = repoToken;
+                listData.nodes[repoToken].next = NULL_NODE;
                 break;
             }
 

--- a/src/TermAuctionList.sol
+++ b/src/TermAuctionList.sol
@@ -103,6 +103,7 @@ library TermAuctionList {
         // If the list is empty, set the new repoToken as the head
         if (current == NULL_NODE) {
             listData.head = offerId;
+            listData.nodes[offerId].next = NULL_NODE;
             listData.offers[offerId] = pendingOffer;
             return;
         }
@@ -119,7 +120,7 @@ library TermAuctionList {
             address auctionToInsert = address(pendingOffer.termAuction);
 
             // Insert repoToken before current if its maturity is less than or equal
-            if (auctionToInsert <= currentAuction) {
+            if (auctionToInsert < currentAuction) {
                 if (prev == NULL_NODE) {
                     listData.head = offerId;
                 } else {
@@ -135,6 +136,7 @@ library TermAuctionList {
             // If at the end of the list, insert repoToken after current
             if (next == NULL_NODE) {
                 listData.nodes[current].next = offerId;
+                listData.nodes[offerId].next = NULL_NODE;
                 break;
             }
 


### PR DESCRIPTION
Fixes two issues in the `RepoTokenList.insertSorted` and `TermAuctionList.insertPending` functions:

1. When a node is inserted at the end of the list (including an empty list) the `next` pointer was not being set to `NULL_NODE`. This means that if for any reason the storage slot of the `next` pointer is not initialized to 0, the list would be left in an inconsistent state. It is safer to assign the pointer to `NULL_NODE` at the time of insertion.
2. When there are two tokens `t1` and `t2` in the list with the same maturity, with `t1` coming first, it was possible to introduce a cycle by inserting `t2` again. The insertion function would stop as soon as it found the first token with the same maturity, inserting `t2` before `t1` without checking to see if it already appeared later on the list. This is fixed by changing the maturity comparison check from `<=` to `<`. The same is the case for comparing between auctions in the `TermAuctionList`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved logic for inserting tokens and auctions based on maturity, enhancing the order of items in lists.
	- Enhanced linked list integrity through explicit management of node pointers.

- **Bug Fixes**
	- Resolved issues with node insertion conditions to ensure proper ordering and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->