### PR TITLE
RepoTokenList small fixes

### DIFF
--- a/src/RepoTokenList.sol
+++ b/src/RepoTokenList.sol
@@ -243,7 +243,7 @@ library RepoTokenList {
         address prev = current;
         while (current != NULL_NODE) {
             address next;
-            if (getRepoTokenMaturity(current) < block.timestamp) {
+            if (getRepoTokenMaturity(current) <= block.timestamp) {
                 bool removeMaturedToken;
                 uint256 repoTokenBalance = ITermRepoToken(current).balanceOf(address(this));
 
@@ -388,6 +388,8 @@ library RepoTokenList {
             return;
         }
 
+        uint256 maturityToInsert = getRepoTokenMaturity(repoToken);
+
         address prev;
         while (current != NULL_NODE) {
 
@@ -397,7 +399,6 @@ library RepoTokenList {
             }
 
             uint256 currentMaturity = getRepoTokenMaturity(current);
-            uint256 maturityToInsert = getRepoTokenMaturity(repoToken);
 
             // Insert repoToken before current if its maturity is less than or equal
             if (maturityToInsert < currentMaturity) {


### PR DESCRIPTION
Makes two small fixes to `RepoTokenList`:

- Change `<` to `<=` when comparing the maturity with the current timestamp in `removeAndRedeemMaturedTokens`, to make it consistent with other functions.
- Pull `getRepoTokenMaturity(repoToken)` out of the loop in `insertSorted`, so it can be called only once instead of at every iteration.