### PR TITLE
Reverted `lockedOfferAmount` function

### DIFF
--- a/src/TermAuctionList.sol
+++ b/src/TermAuctionList.sol
@@ -173,7 +173,7 @@ library TermAuctionList {
             PendingOffer memory offer = listData.offers[current];
             bytes32 next = _getNext(listData, current);
 
-            uint256 offerAmount = offer.offerLocker.lockedOfferAmount(current);
+            uint256 offerAmount = offer.offerLocker.lockedOffer(current).amount;
             bool removeNode;
             bool insertRepoToken;
 
@@ -263,7 +263,7 @@ library TermAuctionList {
                 continue;
             }
 
-            uint256 offerAmount = offer.offerLocker.lockedOfferAmount(current);
+            uint256 offerAmount = offer.offerLocker.lockedOffer(current).amount;
 
             // Handle new or unseen repo tokens
             /// @dev offer processed, but auctionClosed not yet called and auction is new so repoToken not on List and wont be picked up
@@ -338,7 +338,7 @@ library TermAuctionList {
                 found = true;
             } else {
                 // Retrieve the current offer amount from the offer locker
-                offerAmount = offer.offerLocker.lockedOfferAmount(current);
+                offerAmount = offer.offerLocker.lockedOffer(current).amount;
 
                 // Handle new repo tokens or reopening auctions
                 /// @dev offer processed, but auctionClosed not yet called and auction is new so repoToken not on List and wont be picked up

--- a/src/interfaces/term/ITermAuctionOfferLocker.sol
+++ b/src/interfaces/term/ITermAuctionOfferLocker.sol
@@ -50,8 +50,6 @@ interface ITermAuctionOfferLocker {
 
     function lockedOffer(bytes32 id) external view returns (TermAuctionOffer memory);
 
-    function lockedOfferAmount(bytes32 id) external view returns (uint256);
-
     /// @param offerSubmissions An array of offer submissions
     /// @return A bytes32 array of unique on chain offer ids.
     function lockOffers(

--- a/src/test/kontrol/TermAuctionListInvariants.t.sol
+++ b/src/test/kontrol/TermAuctionListInvariants.t.sol
@@ -212,7 +212,7 @@ contract TermAuctionListInvariantsTest is KontrolTest {
         while (current != TermAuctionList.NULL_NODE) {
             if(offerId == 0 || offerId != current) {
                 PendingOffer storage offer = _termAuctionList.offers[current];
-                uint256 offerAmount = offer.offerLocker.lockedOfferAmount(current);
+                uint256 offerAmount = offer.offerLocker.lockedOffer(current).amount;
                 _establish(mode, offer.offerAmount == offerAmount);
             }
 
@@ -334,7 +334,7 @@ contract TermAuctionListInvariantsTest is KontrolTest {
         offerLocker.initializeSymbolicLockedOfferFor(offerId);
         (,, address termRepoServicer, address termRepoCollateralManager) =
             repoToken.config();
-        vm.assume(0 < offerLocker.lockedOfferAmount(offerId));
+        vm.assume(0 < offerLocker.lockedOffer(offerId).amount);
         vm.assume(auction != address(repoToken));
         vm.assume(auction != address(offerLocker));
         vm.assume(auction != termRepoServicer);
@@ -348,7 +348,7 @@ contract TermAuctionListInvariantsTest is KontrolTest {
         // Build new PendingOffer
         PendingOffer memory pendingOffer;
         pendingOffer.repoToken = address(repoToken);
-        pendingOffer.offerAmount = offerLocker.lockedOfferAmount(offerId);
+        pendingOffer.offerAmount = offerLocker.lockedOffer(offerId).amount;
         pendingOffer.termAuction = ITermAuction(auction);
         pendingOffer.offerLocker = ITermAuctionOfferLocker(offerLocker);
 
@@ -410,7 +410,7 @@ contract TermAuctionListInvariantsTest is KontrolTest {
         vm.assume(offer.offerLocker == pendingOffer.offerLocker);
         // This is being checked by Strategy.submitAuctionOffer
         vm.assume(pendingOffer.offerAmount > 0);
-        vm.assume(pendingOffer.offerAmount == pendingOffer.offerLocker.lockedOfferAmount(offerId));
+        vm.assume(pendingOffer.offerAmount == pendingOffer.offerLocker.lockedOffer(offerId).amount);
 
         // Call the function being tested
         _termAuctionList.insertPending(offerId, pendingOffer);

--- a/src/test/mocks/MockTermAuctionOfferLocker.sol
+++ b/src/test/mocks/MockTermAuctionOfferLocker.sol
@@ -48,10 +48,6 @@ contract MockTermAuctionOfferLocker is ITermAuctionOfferLocker {
         return lockedOffers[id];
     }
 
-    function lockedOfferAmount(bytes32 id) external view returns (uint256) {
-        return lockedOffers[id].amount;
-    }
-
     function lockOffers(
         TermAuctionOfferSubmission[] calldata offerSubmissions
     ) external returns (bytes32[] memory offerIds) {


### PR DESCRIPTION
This PR reverts the changes introduced by this [commit](https://github.com/term-finance/yearn-v3-term-vault/pull/47/commits/06e78c2e458b77fe11fcc59a1746791f15e955f5#diff-c52b33568a2f178032ff9cf29539e6d75bde6756cf9dfb702c02eb5ae0423e9e). More concretely it replaces back calls to the function `TermAuctionOfferLocker.lockedOfferAmount` function, since the `TermAuctionOfferLocker` is not possible to change.