### PR TITLE
Add CI/CodeCov badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Tokenized Strategy Mix for Yearn V3 strategies
 
+![CI](https://github.com/term-finance/yearn-v3-term-vault/actions/workflows/ci.yaml/badge.svg?branch=master)
+
+[![codecov](https://codecov.io/gh/term-finance/yearn-v3-term-vault/graph/badge.svg?token=rSmJK0e9nG)](https://codecov.io/gh/term-finance/yearn-v3-term-vault)
+
 This repo will allow you to write, test and deploy V3 "Tokenized Strategies" using [Foundry](https://book.getfoundry.sh/).
 
 You will only need to override the three functions in Strategy.sol of `_deployFunds`, `_freeFunds` and `_harvestAndReport`. With the option to also override `_tend`, `_tendTrigger`, `availableDepositLimit`, `availableWithdrawLimit` and `_emergencyWithdraw` if desired.


### PR DESCRIPTION
Currently codecov is not setup to run with this repo. That will also need to be configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added Continuous Integration and Codecov badges to the README for improved visibility of project health metrics.
	- Retained existing setup, cloning, building, and testing instructions for user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->