### PR TITLE
Adds codecov integration to repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,5 +22,9 @@ jobs:
           forge test --no-match-path "src/test/kontrol/*" -vvv
       - name: Run snapshot without Kontrol tests
         run: forge snapshot --no-match-path "src/test/kontrol/*"
-
+      - name: Run coverage without Kontrol tests
+        run: forge coverage --report lcov --no-match-path "src/test/kontrol/*"
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   


### PR DESCRIPTION
Needs the Github secret `CODECOV_TOKEN` to be filled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new step in the CI workflow for generating coverage reports, excluding specific tests.
	- Added integration with Codecov for automatic coverage report uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->