### PR TITLE
free funds loose amount

### DIFF
--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -1328,13 +1328,20 @@ contract Strategy is BaseStrategy, Pausable, AccessControl {
      * entirely permissionless and thus can be sandwiched or otherwise
      * manipulated.
      *
-     * Should not rely on asset.balanceOf(address(this)) calls other than
-     * for diff accounting purposes.
-     *
      * Any difference between `_amount` and what is actually freed will be
      * counted as a loss and passed on to the withdrawer. This means
      * care should be taken in times of illiquidity. It may be better to revert
      * if withdraws are simply illiquid so not to realize incorrect losses.
+     *
+     * NOTE: This intentionally reads `asset.balanceOf(address(this))` to
+     * capture the already-loose balance. `_redeemRepoTokens` treats its
+     * argument as the target loose balance to end with, so the target must
+     * be `loose + _amount` to leave the strategy holding the full amount the
+     * {TokenizedStrategy} expects (`idle + _amount`). Targeting only `_amount`
+     * would re-deposit the pre-existing loose balance and under-free the
+     * withdrawal, realizing a phantom loss for the withdrawer. This is the
+     * one place `balanceOf` is relied on beyond diff accounting, and it is
+     * deliberate.
      *
      * @param _amount, The amount of 'asset' to be freed.
      */

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -1339,7 +1339,8 @@ contract Strategy is BaseStrategy, Pausable, AccessControl {
      * @param _amount, The amount of 'asset' to be freed.
      */
     function _freeFunds(uint256 _amount) internal override whenNotPaused {
-        _redeemRepoTokens(_amount);
+        uint256 loose = IERC20(asset).balanceOf(address(this));
+        _redeemRepoTokens(loose + _amount);
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withdrawals by correctly considering any pre-existing idle (“loose”) asset already held by the strategy.
  * Redemption now targets the combined available loose balance plus the requested amount, preventing already-holdings from being unintentionally re-included in redeem/redeposit flows.
  * This reduces the risk of withdrawal shortfalls and improves coverage consistency during redeem/redeposit operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->