### PR TITLE
repo token validation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ out = 'out'
 libs = ['lib']
 solc = "0.8.23"
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 50
 
 remappings = [
     "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/",
@@ -18,3 +18,6 @@ remappings = [
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
+
+[lint]
+lint_on_build = false

--- a/src/TwoWayStrategy.sol
+++ b/src/TwoWayStrategy.sol
@@ -1203,6 +1203,14 @@ contract TwoWayStrategy is BaseStrategy, Pausable, AccessControl {
             revert RepoTokenList.InvalidRepoToken(repoToken);
         }
 
+        (bool isRepoTokenValid, ) = repoTokenListData.validateRepoToken(
+            ITermRepoToken(repoToken),
+            address(asset)
+        );
+        if (!isRepoTokenValid) {
+            revert RepoTokenList.InvalidRepoToken(repoToken);
+        }
+
         // Redeem matured inventory first so we don't sell tokens that should be cash
         _redeemRepoTokens(0);
 

--- a/src/test/TestUSDCBuyRepoToken.t.sol
+++ b/src/test/TestUSDCBuyRepoToken.t.sol
@@ -238,6 +238,146 @@ contract TestUSDCBuyRepoToken is Setup {
         termStrategy.buyRepoToken(address(repoToken1Week), 0);
     }
 
+    /// @dev The new validateRepoToken gate in buyRepoToken rejects matured
+    /// repoTokens. When redemption is failing (default / servicer not open),
+    /// the token stays in the strategy's inventory with no way to sell it out.
+    function testBuyMaturedRepoTokenReverts() public {
+        uint256 repoTokenAmount = 1e18;
+        _seedInventory(repoTokenAmount);
+
+        // Redemption fails, so the matured token cannot be swept out of inventory
+        repoToken1Week.mockServicer().setRedemptionFailure(true);
+        vm.warp(block.timestamp + 1 weeks + 1);
+
+        mockUSDC.mint(buyer, 100e6);
+        vm.startPrank(buyer);
+        mockUSDC.approve(address(strategy), type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RepoTokenList.InvalidRepoToken.selector,
+                address(repoToken1Week)
+            )
+        );
+        termStrategy.buyRepoToken(address(repoToken1Week), repoTokenAmount);
+        vm.stopPrank();
+
+        // Redemption sweep cannot clear it either: the inventory is stuck
+        termStrategy.auctionClosed();
+        assertEq(
+            repoToken1Week.balanceOf(address(strategy)),
+            repoTokenAmount
+        );
+    }
+
+    /// @dev Governance raising the required min collateral ratio above the
+    /// term's maintenance ratio invalidates an already-held repoToken.
+    function testBuyRepoTokenRevertsWhenMinCollateralRatioRaised() public {
+        uint256 repoTokenAmount = 1e18;
+        _seedInventory(repoTokenAmount);
+
+        // Term maintenance ratio for mockCollateral is 1e18; require more
+        vm.prank(governor);
+        termStrategy.setCollateralTokenParams(address(mockCollateral), 1.5e18);
+
+        mockUSDC.mint(buyer, 100e6);
+        vm.startPrank(buyer);
+        mockUSDC.approve(address(strategy), type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RepoTokenList.InvalidRepoToken.selector,
+                address(repoToken1Week)
+            )
+        );
+        termStrategy.buyRepoToken(address(repoToken1Week), repoTokenAmount);
+        vm.stopPrank();
+    }
+
+    /// @dev Zeroing a collateral token's params (de-listing it) also
+    /// invalidates an already-held repoToken backed by that collateral.
+    function testBuyRepoTokenRevertsWhenCollateralTokenDelisted() public {
+        uint256 repoTokenAmount = 1e18;
+        _seedInventory(repoTokenAmount);
+
+        vm.prank(governor);
+        termStrategy.setCollateralTokenParams(address(mockCollateral), 0);
+
+        mockUSDC.mint(buyer, 100e6);
+        vm.startPrank(buyer);
+        mockUSDC.approve(address(strategy), type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RepoTokenList.InvalidRepoToken.selector,
+                address(repoToken1Week)
+            )
+        );
+        termStrategy.buyRepoToken(address(repoToken1Week), repoTokenAmount);
+        vm.stopPrank();
+    }
+
+    /// @dev A repoToken denominated in some other purchase token can only reach
+    /// the strategy by donation; buyRepoToken now refuses to price it.
+    function testBuyRepoTokenRevertsOnPurchaseTokenMismatch() public {
+        uint256 repoTokenAmount = 1e18;
+        ERC20Mock otherAsset = new ERC20Mock();
+        MockTermRepoToken foreignRepoToken = new MockTermRepoToken(
+            bytes32("foreign repo token"),
+            address(otherAsset),
+            address(mockCollateral),
+            1e18,
+            block.timestamp + 1 weeks
+        );
+
+        // Donate the foreign repoToken into the strategy
+        foreignRepoToken.mint(address(strategy), repoTokenAmount);
+        // Priced normally, so the purchase token mismatch is the only failure
+        termController.setOracleRate(foreignRepoToken.termRepoId(), 0.05e18);
+
+        mockUSDC.mint(buyer, 100e6);
+        vm.startPrank(buyer);
+        mockUSDC.approve(address(strategy), type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RepoTokenList.InvalidRepoToken.selector,
+                address(foreignRepoToken)
+            )
+        );
+        termStrategy.buyRepoToken(address(foreignRepoToken), repoTokenAmount);
+        vm.stopPrank();
+    }
+
+    /// @dev Documents the asymmetry introduced by the new gate: once a
+    /// repoToken is in the list, validateAndInsertRepoToken short-circuits and
+    /// skips the collateral checks, so sellRepoToken still accepts a token that
+    /// buyRepoToken now rejects. Tokens can enter but not leave.
+    function testSellStillAllowedAfterMinCollateralRatioRaised() public {
+        uint256 repoTokenAmount = 1e18;
+        _seedInventory(repoTokenAmount);
+
+        vm.prank(governor);
+        termStrategy.setCollateralTokenParams(address(mockCollateral), 1.5e18);
+
+        repoToken1Week.mint(seller, repoTokenAmount);
+        vm.prank(seller);
+        termStrategy.sellRepoToken(address(repoToken1Week), repoTokenAmount);
+
+        assertEq(
+            repoToken1Week.balanceOf(address(strategy)),
+            repoTokenAmount * 2
+        );
+
+        mockUSDC.mint(buyer, 100e6);
+        vm.startPrank(buyer);
+        mockUSDC.approve(address(strategy), type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RepoTokenList.InvalidRepoToken.selector,
+                address(repoToken1Week)
+            )
+        );
+        termStrategy.buyRepoToken(address(repoToken1Week), repoTokenAmount);
+        vm.stopPrank();
+    }
+
     function testSetDiscountRateBuyMarkup() public {
         vm.expectRevert();
         termStrategy.setDiscountRateBuyMarkup(12345);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repo token purchases by validating token eligibility before redemption.
  * Purchases are now rejected when tokens are matured, delisted, tied to an invalid collateral ratio, or use a mismatched purchase token.
  * Selling repo tokens remains available after collateral requirements change.
  * Failed redemptions preserve tokens in strategy inventory after an auction closes.

* **Performance**
  * Reduced build optimization time for faster development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->